### PR TITLE
comment out console log that crashes on google cal add

### DIFF
--- a/app/controllers/appointment.controller.js
+++ b/app/controllers/appointment.controller.js
@@ -551,7 +551,7 @@ function addEvent(auth, data) {
     .then((event) => console.log('Event created: %s', event))
     .catch((error) => {
       console.log('Some error occured', error)
-      console.log(error.response.data.error.errors);
+      // console.log(error.response.data.error.errors);
     });
 }
 


### PR DESCRIPTION
comented out console.log that was causing a crash when google calendar add failed.