### PR TITLE
Fix filtering for appointments needing feedback

### DIFF
--- a/app/controllers/appointment.controller.js
+++ b/app/controllers/appointment.controller.js
@@ -121,7 +121,10 @@ exports.findAllPassedForPersonForGroupTutor = (req, res) => {
   date.setHours(0,0,0);
 
   Appointment.findAll({
-    where: { groupId: groupId, date: { [Op.lte]: date }, endTime: { [Op.lt]: endTime }, [Op.or]: [{ status: {[Op.like]: "booked" }, type: { [Op.like]: "Group" }}], },
+    where: { groupId: groupId, 
+            date: { [Op.lte]: date }, 
+            endTime: { [Op.lt]: endTime }, 
+            [Op.or]: [{ status: {[Op.like]: "booked" }}, {type: { [Op.like]: "Group" }}] },
     include: [{
       where: { '$personappointment.personId$': personId, feedbacknumber: { [Op.eq]: null }, feedbacktext: { [Op.eq]: null } },
       model: PersonAppointment,

--- a/app/controllers/appointment.controller.js
+++ b/app/controllers/appointment.controller.js
@@ -124,6 +124,8 @@ exports.findAllPassedForPersonForGroupTutor = (req, res) => {
     where: { groupId: groupId, 
             date: { [Op.lte]: date }, 
             endTime: { [Op.lt]: endTime }, 
+            status: { [Op.notLike]: "tutorCancel"},
+            status: { [Op.notLike]: "studentCancel"},
             [Op.or]: [{ status: {[Op.like]: "booked" }}, {type: { [Op.like]: "Group" }}] },
     include: [{
       where: { '$personappointment.personId$': personId, feedbacknumber: { [Op.eq]: null }, feedbacktext: { [Op.eq]: null } },

--- a/app/controllers/appointment.controller.js
+++ b/app/controllers/appointment.controller.js
@@ -115,10 +115,12 @@ exports.findAllUpcomingForPersonForGroup = (req, res) => {
 exports.findAllPassedForPersonForGroupTutor = (req, res) => {
   const personId = req.params.personId;
   const groupId = req.params.groupId;
-  const date = new Date();
+  let date = new Date();
+  date.setHours(date.getHours() - (date.getTimezoneOffset()/60))
+  date.setHours(0,0,0);
 
   Appointment.findAll({
-    where: { groupId: groupId, date: { [Op.lte]: date }, status: { [Op.like]: "booked" }},
+    where: { groupId: groupId, date: { [Op.lte]: date }, endTime: { [Op.lt]: date }, [Op.or]: [{ status: {[Op.like]: "booked" }, type: { [Op.like]: "Group" }}], },
     include: [{
       where: { '$personappointment.personId$': personId, feedbacknumber: { [Op.eq]: null }, feedbacktext: { [Op.eq]: null } },
       model: PersonAppointment,

--- a/app/controllers/appointment.controller.js
+++ b/app/controllers/appointment.controller.js
@@ -116,11 +116,12 @@ exports.findAllPassedForPersonForGroupTutor = (req, res) => {
   const personId = req.params.personId;
   const groupId = req.params.groupId;
   let date = new Date();
+  let endTime = date.toLocaleTimeString('it-IT')
   date.setHours(date.getHours() - (date.getTimezoneOffset()/60))
   date.setHours(0,0,0);
 
   Appointment.findAll({
-    where: { groupId: groupId, date: { [Op.lte]: date }, endTime: { [Op.lt]: date }, [Op.or]: [{ status: {[Op.like]: "booked" }, type: { [Op.like]: "Group" }}], },
+    where: { groupId: groupId, date: { [Op.lte]: date }, endTime: { [Op.lt]: endTime }, [Op.or]: [{ status: {[Op.like]: "booked" }, type: { [Op.like]: "Group" }}], },
     include: [{
       where: { '$personappointment.personId$': personId, feedbacknumber: { [Op.eq]: null }, feedbacktext: { [Op.eq]: null } },
       model: PersonAppointment,

--- a/app/controllers/appointment.controller.js
+++ b/app/controllers/appointment.controller.js
@@ -124,8 +124,7 @@ exports.findAllPassedForPersonForGroupTutor = (req, res) => {
     where: { groupId: groupId, 
             date: { [Op.lte]: date }, 
             endTime: { [Op.lt]: endTime }, 
-            status: { [Op.notLike]: "tutorCancel"},
-            status: { [Op.notLike]: "studentCancel"},
+            [Op.and]: [{status: {[Op.notLike]: "tutorCancel"}}, {status: { [Op.notLike]: "studentCancel"}}],
             [Op.or]: [{ status: {[Op.like]: "booked" }}, {type: { [Op.like]: "Group" }}] },
     include: [{
       where: { '$personappointment.personId$': personId, feedbacknumber: { [Op.eq]: null }, feedbacktext: { [Op.eq]: null } },


### PR DESCRIPTION
I updated the appointments needing feedback filter to account for the case that
1. appointment is group and will never have "booked" status
2. appointment is happening today but endtime has not passed yet