### PR TITLE
fixed logout error

### DIFF
--- a/app/controllers/auth.controller.js
+++ b/app/controllers/auth.controller.js
@@ -253,7 +253,8 @@ exports.logout = async (req, res) => {
 
     await Session.findAll({ where: { token : req.body.token } })
     .then(data => {
-        session = data[0].dataValues;
+        if(data[0] !== undefined)
+            session = data[0].dataValues;
     })
     .catch(err => {
         res.status(500).send({
@@ -264,7 +265,8 @@ exports.logout = async (req, res) => {
 
     session.token = '';
 
-    if(session !== null && session !== undefined) {
+    // session won't be null but the id will if no session was found
+    if(session.id !== undefined) {
         Session.update(session, { where: { id: session.id } })
         .then(num => {
             if (num == 1) {
@@ -286,7 +288,6 @@ exports.logout = async (req, res) => {
             });
         }); 
     }
-    
     else {
         console.log("already logged out")
         res.send({


### PR DESCRIPTION
I found that the logout function still wasn't quite working correctly. Errors were being thrown that we weren't handling when trying to find a session that didn't exist. That caused headers to try to be sent more than once, which it can't handle. It now checks for all the right data.